### PR TITLE
Added simple_square_brackets and expand_vowels transforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,11 @@ The following transforms are currently available:
 - ``transliterate_circled`` - Takes the input string and returns a copy with circled versions of the letters e.g. ``Hello`` -> ``Ⓗⓔⓛⓛⓞ``
 - ``transliterate_fullwidth`` - Takes the input string and returns a copy with the letters converted to their fullwidth counterparts e.g. ``Hello`` -> ``Ｈｅｌｌｏ``
 - ``pad_length`` - Appends a series of characters to the end of the input string to increase the string length per `IBM Globalization Design Guideline A3: UI Expansion <https://www-01.ibm.com/software/globalization/guidelines/a3.html>`_.
+- ``expand_vowels`` - Replicates the vowels of the input string to increase the string length per `IBM Globalization Design Guideline A3: UI Expansion <https://www-01.ibm.com/software/globalization/guidelines/a3.html>`_.
 - ``angle_brackets`` - Surrounds the input string with '《' and '》' characters.
 - ``curly_brackets`` - Surrounds the input string with '❴' and '❵' characters.
 - ``square_brackets`` - Surrounds the input string with '⟦' and '⟧' characters.
+- ``simple_square_brackets`` - Surrounds the input string with '[' and ']' characters.
 
 
 Format string support

--- a/pseudol10nutil/transforms.py
+++ b/pseudol10nutil/transforms.py
@@ -23,6 +23,7 @@ def __get_target_length(size):
         six.moves.range(31, 51): 1.6,
         six.moves.range(51, 71): 1.4,
     }
+    target_length = 0
     if size > 70:
         target_length = int(math.ceil(size * 1.3))
     else:

--- a/test_pseudol10nutil.py
+++ b/test_pseudol10nutil.py
@@ -110,11 +110,39 @@ class TestPseudoL10nUtil(unittest.TestCase):
         self.util.transforms = [pseudol10nutil.transforms.square_brackets]
         self.assertEqual(expected, self.util.pseudolocalize(self.test_data))
 
+    def test_simple_square_brackets(self):
+        expected = u"[The quick brown fox jumps over the lazy dog]"
+        self.util.transforms = [pseudol10nutil.transforms.simple_square_brackets]
+        self.assertEqual(expected, self.util.pseudolocalize(self.test_data))
+
     def test_pad_length(self):
         expected = u"The quick brown fox jumps over the lazy dog﹎ЍאǆᾏⅧ㈴㋹퓛ﺏ𝟘🚦﹎ЍאǆᾏⅧ㈴㋹퓛ﺏ𝟘🚦﹎Ѝ"
         self.util.transforms = [pseudol10nutil.transforms.pad_length]
         self.assertEqual(expected, self.util.pseudolocalize(self.test_data))
 
+    def test_expand_vowels_no_vowels(self):
+        test_data = u"jmpng"
+        expected = u"jmpnggggggggggg"
+        self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
+        self.assertEqual(expected, self.util.pseudolocalize(test_data))
+
+    def test_expand_vowels_one_vowel(self):
+        test_data = u"Row"
+        expected = u"Rooooooow"
+        self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
+        self.assertEqual(expected, self.util.pseudolocalize(test_data))
+
+    def test_expand_vowels_vowel_in_placeholder(self):
+        test_data_printffmtspec = u"Source %(source0)s returned 0 rows, source %(source1)s returned 1 row."
+        expected = u"Sooouuurceee %(source0)s reeetuuurneeed 0 rooows, sooouuurceee %(source1)s reeetuuurneeed 1 roooow."
+        self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
+        self.assertEqual(expected, self.util.pseudolocalize(test_data_printffmtspec))
+
+    def test_expand_vowels_transliterated_source(self):
+        test_data_printffmtspec = u"Șøüȓċê %(source0)s ȓêťüȓñêđ 0 ȓøẁš, šøüȓċê %(source1)s ȓêťüȓñêđ 1 ȓøẁ."
+        expected = u"Șøøøüüüȓċêêê %(source0)s ȓêêêťüüüȓñêêêđ 0 ȓøøøẁš, šøøøüüüȓċêêê %(source1)s ȓêêêťüüüȓñêêêđ 1 ȓøøøøẁ."
+        self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
+        self.assertEqual(expected, self.util.pseudolocalize(test_data_printffmtspec))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_pseudol10nutil.py
+++ b/test_pseudol10nutil.py
@@ -144,5 +144,12 @@ class TestPseudoL10nUtil(unittest.TestCase):
         self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
         self.assertEqual(expected, self.util.pseudolocalize(test_data_printffmtspec))
 
+    def test_expand_vowels_placeholder_only(self):
+        test_data_printffmtspec = u"%(source0)s"
+        expected = u"%(source0)s"
+        self.util.transforms = [pseudol10nutil.transforms.expand_vowels]
+        self.assertEqual(expected, self.util.pseudolocalize(test_data_printffmtspec))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi, I was tasked with finding a pseudolocalisation library in Python and your project stuck out. Wanted to contribute back some of the extensions we've implemented :)

We've added two new transform functions:
- simple_square_brackets - add [ and ] around the string to signify the boundaries. Added to allow for more options for boundary characters.
- expand_vowels - implements the suggestion from the Netflix article https://netflixtechblog.com/pseudo-localization-netflix-12fff76fbcbe Keeps the string easier to read and understand and clear what is part of it and what isn't while still expanding the length.

In terms of backwards compatibility, there should be no issue. Each transform now receives the placeholder/format regex used in order to allow for more complex transforms (such as the expand_vowels which needed to know where all the placeholders are.